### PR TITLE
Make concat work with null

### DIFF
--- a/library/Garp/Functional/Concat.php
+++ b/library/Garp/Functional/Concat.php
@@ -19,7 +19,7 @@ function concat() {
     $concatter = function () {
         $args = func_get_args();
         $toArray = function ($var) {
-            return (array) $var;
+            return is_array($var) ? $var : [$var];
         };
         if (some(unary('is_array'), $args)) {
             return call_user_func_array(

--- a/tests/ConcatTest.php
+++ b/tests/ConcatTest.php
@@ -121,6 +121,12 @@ class ConcatTest extends TestCase {
         );
     }
 
+    public function test_should_concat_null() {
+        $actual = f\concat(['test'], null);
+
+        $this->assertEquals(['test', null], $actual);
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
Make `concat(['a'], null);` return `['a', null]` instead of `['a']`