### PR TITLE
Prevent rename_keys from calling functions

### DIFF
--- a/library/Garp/Functional/RenameKeys.php
+++ b/library/Garp/Functional/RenameKeys.php
@@ -25,9 +25,10 @@ function rename_keys($transformMap, array $collection = null) {
                 $prop = is_callable($transformMap)
                     ? $transformMap($cur)
                     : prop($cur, $transformMap);
+
                 return prop_set(
                     $prop ?: $cur,
-                    $collection[$cur],
+                    always($collection[$cur]), // Why? Because: https://github.com/grrr-amsterdam/garp-functional/pull/20
                     $acc
                 );
             },

--- a/tests/RenameKeysTest.php
+++ b/tests/RenameKeysTest.php
@@ -78,6 +78,15 @@ class RenameKeysTest extends TestCase {
         );
     }
 
+    public function test_callable_should_not_be_executed_in_collection() {
+        $actual = f\rename_keys(
+            array(0 => 'new_key'),
+            array('Garp\Functional\rename_keys')
+        );
+
+        $this->assertEquals(array('new_key' => 'Garp\Functional\rename_keys'), $actual);
+    }
+
     public function test_should_be_curried() {
         $renamer = f\rename_keys(array('foo' => 'bar'));
         $this->assertTrue(is_callable($renamer));


### PR DESCRIPTION
When the collection contains a string that matches a function name available in your app it wil be executed by `prop_set`. Because the `$value` argument of `prop_set` could by a callable. To prevent that from happening the value is wrapped in a callable. Now `prop_set` executes the `always` function that will always return the value.