### PR TITLE
[Prototype] Refactor reduce to allow early return

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
       "Garp\\": "library/"
     },
     "files": [
+      "library/Garp/Functional/_internal/ReducedValue.php",
       "library/Garp/Functional/Add.php",
       "library/Garp/Functional/Always.php",
       "library/Garp/Functional/Autocurry.php",
@@ -60,6 +61,7 @@
       "library/Garp/Functional/Instance.php",
       "library/Garp/Functional/IsAssoc.php",
       "library/Garp/Functional/IsCallableFunction.php",
+      "library/Garp/Functional/IsReduced.php",
       "library/Garp/Functional/Join.php",
       "library/Garp/Functional/Keys.php",
       "library/Garp/Functional/KeysWhere.php",
@@ -88,6 +90,7 @@
       "library/Garp/Functional/Publish.php",
       "library/Garp/Functional/Reduce.php",
       "library/Garp/Functional/ReduceAssoc.php",
+      "library/Garp/Functional/Reduced.php",
       "library/Garp/Functional/Reindex.php",
       "library/Garp/Functional/Reject.php",
       "library/Garp/Functional/RenameKeys.php",

--- a/library/Garp/Functional/DropWhile.php
+++ b/library/Garp/Functional/DropWhile.php
@@ -23,16 +23,15 @@ function drop_while(callable $predicate, $collection = null) {
             if (!is_array($collection) && !$collection instanceof \Traversable) {
                 throw new \InvalidArgumentException('drop_while expects argument 2 to be a collection');
             }
-            $out = [];
-            $gotSome = false;
-            foreach ($collection as $key => $value) {
-                if (!$gotSome && $predicate($value)) {
-                    continue;
-                }
-                $gotSome = true;
-                $out[] = $value;
-            }
-            return $out;
+            return reduce(
+                function ($collection, $item) use ($predicate) {
+                    return !count($collection) && $predicate($item)
+                        ? $collection
+                        : concat($collection, [$item]);
+                },
+                [],
+                $collection
+            );
         },
         2
     )(...func_get_args());

--- a/library/Garp/Functional/Find.php
+++ b/library/Garp/Functional/Find.php
@@ -18,8 +18,13 @@ namespace Garp\Functional;
 function find(callable $predicate, iterable $collection = null) {
     return autocurry(
         function ($predicate, $collection) {
-            $filtered = filter($predicate, $collection);
-            return current($filtered) ?: null;
+            return reduce(
+                function ($acc, $item) use ($predicate) {
+                    return $predicate($item) ? reduced($item) : $acc;
+                },
+                null,
+                $collection
+            );
         },
         2
     )(...func_get_args());

--- a/library/Garp/Functional/FindIndex.php
+++ b/library/Garp/Functional/FindIndex.php
@@ -18,10 +18,13 @@ namespace Garp\Functional;
 function find_index(callable $predicate, iterable $collection = null) {
     return autocurry(
         function ($predicate, $collection) {
-            $collection = is_array($collection) ? $collection : iterator_to_array($collection);
-            $keys = keys(array_filter($collection, $predicate));
-            $first = current($keys);
-            return $first !== false ? $first : null;
+            return reduce_assoc(
+                function ($acc, $item, $key) use ($predicate) {
+                    return $predicate($item) ? reduced($key) : $acc;
+                },
+                null,
+                $collection
+            );
         },
         2
     )(...func_get_args());

--- a/library/Garp/Functional/IsReduced.php
+++ b/library/Garp/Functional/IsReduced.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package  Garp\Functional
+ * @author   Harmen Janssen <harmen@grrr.nl>
+ * @license  https://github.com/grrr-amsterdam/garp-functional/blob/master/LICENSE.md BSD-3-Clause
+ */
+namespace Garp\Functional;
+
+/**
+ * Whether a value is reduced.
+ *
+ * @param  mixed $value
+ * @return bool
+ */
+function is_reduced($value): bool {
+    return $value instanceof ReducedValue;
+}

--- a/library/Garp/Functional/Reduce.php
+++ b/library/Garp/Functional/Reduce.php
@@ -18,16 +18,17 @@ namespace Garp\Functional;
  * @return mixed
  */
 function reduce(callable $fn, $default, iterable $collection = null) {
+    $reduce = function ($fn, $acc, $collection) {
+        foreach ($collection as $item) {
+            $acc = $fn($acc, $item);
+            if (is_reduced($acc)) {
+                return $acc->value;
+            }
+        }
+        return $acc;
+    };
     return autocurry(
-        function ($fn, $default, $collection) {
-            if (is_array($collection)) {
-                return array_reduce($collection, $fn, $default);
-            }
-            if (is_iterable($collection)) {
-                return reduce($fn, $default, iterator_to_array($collection));
-            }
-            throw new \InvalidArgumentException('reduce expects argument 3 to be a collection');
-        },
+        $reduce,
         3
     )(...func_get_args());
 }

--- a/library/Garp/Functional/Reduced.php
+++ b/library/Garp/Functional/Reduced.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package  Garp\Functional
+ * @author   Harmen Janssen <harmen@grrr.nl>
+ * @license  https://github.com/grrr-amsterdam/garp-functional/blob/master/LICENSE.md BSD-3-Clause
+ */
+namespace Garp\Functional;
+
+/**
+ * Declares a value as being "reduced".
+ * This signals a short-circuit to the `reduce` function.
+ *
+ * @param  mixed $value
+ * @return Garp\Functional\ReducedValue
+ */
+function reduced($value): ReducedValue {
+    return is_reduced($value)
+        ? $value
+        : new ReducedValue($value);
+}

--- a/library/Garp/Functional/Some.php
+++ b/library/Garp/Functional/Some.php
@@ -9,21 +9,24 @@ declare(strict_types=1);
 namespace Garp\Functional;
 
 /**
- * Returns TRUE if $callback returns true for one of the items in the collection.
+ * Returns TRUE if $predicate returns true for one of the items in the collection.
  *
- * @param  callable $callback
+ * @param  callable $predicate
  * @param  array    $collection
  * @return bool
  */
-function some(callable $callback, $collection = null) {
+function some(callable $predicate, $collection = null) {
     return autocurry(
-        function ($callback, $collection): bool {
-            foreach ($collection as $index => $item) {
-                if (call_user_func($callback, $item, $index)) {
-                    return true;
-                }
-            }
-            return false;
+        function ($predicate, $collection): bool {
+            return reduce(
+                function ($acc, $item) use ($predicate) {
+                    return $predicate($item)
+                        ? reduced(true)
+                        : $acc;
+                },
+                false,
+                $collection
+            );
         },
         2
     )(...func_get_args());

--- a/library/Garp/Functional/Take.php
+++ b/library/Garp/Functional/Take.php
@@ -16,18 +16,25 @@ namespace Garp\Functional;
  * @return array|string
  */
 function take(int $n, $collection = null) {
+    $reduce = reduce(
+        function ($acc, $item) use ($n) {
+            return count($acc) === $n
+                ? reduced($acc)
+                : concat($acc, [$item]);
+        },
+        []
+    );
     return autocurry(
-        function ($n, $collection) {
-            if (is_array($collection)) {
-                return array_slice($collection, 0, $n);
-            }
+        function ($n, $collection) use ($reduce) {
             if (is_string($collection)) {
-                return substr($collection, 0, $n);
+                $collection = str_split($collection);
+                $reduce = compose(join(''), $reduce);
             }
-            if (is_iterable($collection)) {
-                return take($n, iterator_to_array($collection));
+            $collection = is_string($collection) ? str_split($collection) : $collection;
+            if (!is_iterable($collection)) {
+                throw new \InvalidArgumentException('take expects argument 2 to be a collection');
             }
-            throw new \InvalidArgumentException('take expects argument 2 to be a collection');
+            return $reduce($collection);
         },
         2
     )(...func_get_args());

--- a/library/Garp/Functional/TakeWhile.php
+++ b/library/Garp/Functional/TakeWhile.php
@@ -23,14 +23,15 @@ function take_while(callable $predicate, $collection = null) {
             if (!is_iterable($collection)) {
                 throw new \InvalidArgumentException('take_while expects argument 2 to be a collection');
             }
-            $out = [];
-            foreach ($collection as $key => $value) {
-                if (!$predicate($value)) {
-                    break;
-                }
-                $out[] = $value;
-            }
-            return $out;
+            return reduce(
+                function ($collection, $item) use ($predicate) {
+                    return $predicate($item)
+                        ? concat($collection, [$item])
+                        : reduced($collection);
+                },
+                [],
+                $collection
+            );
         },
         2
     )(...func_get_args());

--- a/library/Garp/Functional/_internal/ReducedValue.php
+++ b/library/Garp/Functional/_internal/ReducedValue.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @package  Garp\Functional
+ * @author   Harmen Janssen <harmen@grrr.nl>
+ * @license  https://github.com/grrr-amsterdam/garp-functional/blob/master/LICENSE.md BSD-3-Clause
+ */
+namespace Garp\Functional;
+
+/**
+ * Object for signaling an early return in a reduce context.
+ *
+ * @package  Garp\Functional
+ * @author   Harmen Janssen <harmen@grrr.nl>
+ * @license  https://github.com/grrr-amsterdam/garp-functional/blob/master/LICENSE.md BSD-3-Clause
+ */
+final class ReducedValue {
+
+    public $value;
+
+    public function __construct($value) {
+        $this->value = $value;
+    }
+
+}
+
+


### PR DESCRIPTION
This is a proof of concept in which an _early return_ mechanism is introduced for reducers. 

A `reduce` function can return an instance of `Garp\Functional\HaltReductionSignal` to stop iteration immediately. 
This can be used to refactor `Garp\Functional\find` and other functions to gain performance.

I'm looking forward to your thoughts, and followup with polishing and further refactoring.