### PR TITLE
Add named function constants for easy composition

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 # Documentation
 
 - [Philosophy](#philosophy)
+- [Function name constants](#function-name-constants)
 - [Function index](#function-index)
 - [Typeclasses](#typeclasses)
 
@@ -42,6 +43,20 @@ $getInitials('Miles Davis'); // M. D.
 ```
 
 Sure, that line is cuckoo, but the idea of composing functions without having to stop at every step to consider the control flow structures, what the parameters are going to be named, and how to return it is pretty powerful.  
+
+## Function name constants
+
+All functions also publish a constant by the same name. This allows you to pass around the function as if you had a reference to it, as is possible in other languages.  
+For example:
+
+```php
+f\compose(
+    f\flatten,
+    f\entries
+);
+```
+
+This works because the constant contains the fully namespaced function name as a string, and therefore qualifies as a `callable`.
 
 ## Function index
 
@@ -274,11 +289,11 @@ Examples:
 ```php
 $a = ['total' => 100, 'amount' => 4];
 $b = ['total' => 50, 'amount' => 5];
-f\concat_with('Garp\Functional\add', $a, $b); // ['total' => 150, 'amount' => 9]
+f\concat_with(f\add, $a, $b); // ['total' => 150, 'amount' => 9]
 
 $c = ['name' => 'Foo'];
 $d = ['name' => 'Bar'];
-f\concat_with('Garp\Functional\concat', $c, $d); // ['name' => 'FooBar']
+f\concat_with(f\concat, $c, $d); // ['name' => 'FooBar']
 ```
 
 ### contains
@@ -1133,7 +1148,7 @@ Curried version of `array_reduce`:
 
 ```php
 $numbers = [20, 43, 15, 12];
-$sum = f\reduce('Garp\Functional\add', 0, $numbers); // 90
+$sum = f\reduce(f\add, 0, $numbers); // 90
 ```
 
 ### reduce_assoc

--- a/functions/add.php
+++ b/functions/add.php
@@ -23,3 +23,5 @@ function add($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const add = '\Garp\Functional\add';

--- a/functions/always.php
+++ b/functions/always.php
@@ -20,3 +20,5 @@ function always($it = null): callable {
         return $it;
     };
 }
+
+const always = '\Garp\Functional\always';

--- a/functions/autocurry.php
+++ b/functions/autocurry.php
@@ -31,3 +31,5 @@ function autocurry(callable $fn, int $arity): callable {
         }
     );
 }
+
+const autocurry = '\Garp\Functional\autocurry';

--- a/functions/binary.php
+++ b/functions/binary.php
@@ -19,3 +19,5 @@ function binary(callable $fn): callable {
         return call_user_func($fn, $x, $y);
     };
 }
+
+const binary = '\Garp\Functional\binary';

--- a/functions/both.php
+++ b/functions/both.php
@@ -32,3 +32,5 @@ function both($left, $right) {
     }
     return $left && $right;
 }
+
+const both = '\Garp\Functional\both';

--- a/functions/call.php
+++ b/functions/call.php
@@ -29,3 +29,5 @@ function call(string $method, array $args = [], $obj = null) {
     };
     return is_null($obj) ? $caller : $caller($obj);
 }
+
+const call = '\Garp\Functional\call';

--- a/functions/compose.php
+++ b/functions/compose.php
@@ -35,3 +35,5 @@ function compose(...$args): callable {
 }
 
 
+
+const compose = '\Garp\Functional\compose';

--- a/functions/concat.php
+++ b/functions/concat.php
@@ -57,3 +57,5 @@ function concat(...$args) {
     }
     return call_user_func_array($concatter, $args);
 }
+
+const concat = '\Garp\Functional\concat';

--- a/functions/concat_right.php
+++ b/functions/concat_right.php
@@ -29,3 +29,5 @@ function concat_right(...$args) {
         array_reverse($args)
     );
 }
+
+const concat_right = '\Garp\Functional\concat_right';

--- a/functions/concat_with.php
+++ b/functions/concat_with.php
@@ -47,3 +47,5 @@ function concat_with(callable $mergeFunction, ...$collections) {
     }
     return call_user_func_array($concatter, $collections);
 }
+
+const concat_with = '\Garp\Functional\concat_with';

--- a/functions/contains.php
+++ b/functions/contains.php
@@ -32,3 +32,5 @@ function contains($item, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const contains = '\Garp\Functional\contains';

--- a/functions/count.php
+++ b/functions/count.php
@@ -26,3 +26,5 @@ function count($subject): int {
         ? \count($subject)
         : mb_strlen(strval($subject));
 }
+
+const count = '\Garp\Functional\count';

--- a/functions/divide.php
+++ b/functions/divide.php
@@ -23,3 +23,5 @@ function divide($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const divide = '\Garp\Functional\divide';

--- a/functions/drop.php
+++ b/functions/drop.php
@@ -32,3 +32,5 @@ function drop(int $n, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const drop = '\Garp\Functional\drop';

--- a/functions/drop_while.php
+++ b/functions/drop_while.php
@@ -36,3 +36,5 @@ function drop_while(callable $predicate, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const drop_while = '\Garp\Functional\drop_while';

--- a/functions/either.php
+++ b/functions/either.php
@@ -30,3 +30,5 @@ function either($left, $right) {
     }
     return $left ?: $right;
 }
+
+const either = '\Garp\Functional\either';

--- a/functions/entries.php
+++ b/functions/entries.php
@@ -22,3 +22,5 @@ function entries(iterable $collection): array {
         keys($collection)
     );
 }
+
+const entries = '\Garp\Functional\entries';

--- a/functions/equals.php
+++ b/functions/equals.php
@@ -27,3 +27,5 @@ function equals($comparison, $subject = null) {
         2
     )(...func_get_args());
 }
+
+const equals = '\Garp\Functional\equals';

--- a/functions/every.php
+++ b/functions/every.php
@@ -29,3 +29,5 @@ function every(callable $fn, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const every = '\Garp\Functional\every';

--- a/functions/filter.php
+++ b/functions/filter.php
@@ -26,3 +26,5 @@ function filter(callable $predicate, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const filter = '\Garp\Functional\filter';

--- a/functions/find.php
+++ b/functions/find.php
@@ -29,3 +29,5 @@ function find(callable $predicate, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const find = '\Garp\Functional\find';

--- a/functions/find_index.php
+++ b/functions/find_index.php
@@ -29,3 +29,5 @@ function find_index(callable $predicate, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const find_index = '\Garp\Functional\find_index';

--- a/functions/flatten.php
+++ b/functions/flatten.php
@@ -27,3 +27,5 @@ function flatten(iterable $collection): array {
     }
     return $results;
 }
+
+const flatten = '\Garp\Functional\flatten';

--- a/functions/flip.php
+++ b/functions/flip.php
@@ -35,3 +35,5 @@ function flip(callable $fn): callable {
         );
     };
 }
+
+const flip = '\Garp\Functional\flip';

--- a/functions/group_by.php
+++ b/functions/group_by.php
@@ -41,3 +41,5 @@ function group_by($indexFn, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const group_by = '\Garp\Functional\group_by';

--- a/functions/gt.php
+++ b/functions/gt.php
@@ -27,3 +27,5 @@ function gt($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const gt = '\Garp\Functional\gt';

--- a/functions/gte.php
+++ b/functions/gte.php
@@ -27,3 +27,5 @@ function gte($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const gte = '\Garp\Functional\gte';

--- a/functions/head.php
+++ b/functions/head.php
@@ -17,3 +17,5 @@ namespace Garp\Functional;
 function head($collection) {
     return prop(0, $collection);
 }
+
+const head = '\Garp\Functional\head';

--- a/functions/id.php
+++ b/functions/id.php
@@ -22,3 +22,5 @@ function id($it = null) {
         1
     )(...func_get_args());
 }
+
+const id = '\Garp\Functional\id';

--- a/functions/index_by.php
+++ b/functions/index_by.php
@@ -39,3 +39,5 @@ function index_by($indexFn, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const index_by = '\Garp\Functional\index_by';

--- a/functions/instance.php
+++ b/functions/instance.php
@@ -24,3 +24,5 @@ function instance($obj) {
     }
     return $obj;
 }
+
+const instance = '\Garp\Functional\instance';

--- a/functions/is_assoc.php
+++ b/functions/is_assoc.php
@@ -19,3 +19,5 @@ function is_assoc(iterable $iterable): bool {
     return !empty($iterable)
         && keys($iterable) !== range(0, count($iterable) - 1);
 }
+
+const is_assoc = '\Garp\Functional\is_assoc';

--- a/functions/is_callable_function.php
+++ b/functions/is_callable_function.php
@@ -27,3 +27,5 @@ function is_callable_function($callable): bool {
     return !is_object($callable) || $callable instanceof \Closure;
 }
 
+
+const is_callable_function = '\Garp\Functional\is_callable_function';

--- a/functions/is_reduced.php
+++ b/functions/is_reduced.php
@@ -17,3 +17,5 @@ namespace Garp\Functional;
 function is_reduced($value): bool {
     return $value instanceof Internal\ReducedValue;
 }
+
+const is_reduced = '\Garp\Functional\is_reduced';

--- a/functions/join.php
+++ b/functions/join.php
@@ -27,3 +27,5 @@ function join(string $separator, $list = null) {
         2
     )(...func_get_args());
 }
+
+const join = '\Garp\Functional\join';

--- a/functions/keys.php
+++ b/functions/keys.php
@@ -31,3 +31,5 @@ function keys($collection): array {
         __FUNCTION__ . ' expects argument 1 to be a collection'
     );
 }
+
+const keys = '\Garp\Functional\keys';

--- a/functions/keys_where.php
+++ b/functions/keys_where.php
@@ -31,3 +31,5 @@ function keys_where(callable $predicate, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const keys_where = '\Garp\Functional\keys_where';

--- a/functions/last.php
+++ b/functions/last.php
@@ -24,3 +24,5 @@ function last($collection) {
     $index = count($collection) - 1;
     return prop($index, array_values($collection));
 }
+
+const last = '\Garp\Functional\last';

--- a/functions/lt.php
+++ b/functions/lt.php
@@ -27,3 +27,5 @@ function lt($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const lt = '\Garp\Functional\lt';

--- a/functions/lte.php
+++ b/functions/lte.php
@@ -27,3 +27,5 @@ function lte($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const lte = '\Garp\Functional\lte';

--- a/functions/map.php
+++ b/functions/map.php
@@ -25,3 +25,5 @@ function map(callable $fn, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const map = '\Garp\Functional\map';

--- a/functions/match.php
+++ b/functions/match.php
@@ -29,3 +29,5 @@ function match(string $regex, $subject = null) {
         2
     )(...func_get_args());
 }
+
+const match = '\Garp\Functional\match';

--- a/functions/merge_after.php
+++ b/functions/merge_after.php
@@ -71,3 +71,5 @@ function merge_after($object, $index, array $target = null) {
         3
     )(...func_get_args());;
 }
+
+const merge_after = '\Garp\Functional\merge_after';

--- a/functions/merge_at.php
+++ b/functions/merge_at.php
@@ -71,3 +71,5 @@ function merge_at($object, $index, array $target = null) {
         3
     )(...func_get_args());
 }
+
+const merge_at = '\Garp\Functional\merge_at';

--- a/functions/modulo.php
+++ b/functions/modulo.php
@@ -23,3 +23,5 @@ function modulo($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const modulo = '\Garp\Functional\modulo';

--- a/functions/multiply.php
+++ b/functions/multiply.php
@@ -23,3 +23,5 @@ function multiply($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const multiply = '\Garp\Functional\multiply';

--- a/functions/none.php
+++ b/functions/none.php
@@ -29,3 +29,5 @@ function none($fn, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const none = '\Garp\Functional\none';

--- a/functions/not.php
+++ b/functions/not.php
@@ -26,3 +26,5 @@ function not(callable $fn): callable {
         return !$fn(...$args);
     };
 }
+
+const not = '\Garp\Functional\not';

--- a/functions/omit.php
+++ b/functions/omit.php
@@ -30,3 +30,5 @@ function omit(array $omitted, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const omit = '\Garp\Functional\omit';

--- a/functions/once.php
+++ b/functions/once.php
@@ -26,3 +26,5 @@ function once(callable $fn): callable {
         return $result;
     };
 }
+
+const once = '\Garp\Functional\once';

--- a/functions/partial.php
+++ b/functions/partial.php
@@ -29,3 +29,5 @@ function partial(callable $fn, ...$args): callable {
         return $fn(...array_merge($args, $remainingArgs));
     };
 }
+
+const partial = '\Garp\Functional\partial';

--- a/functions/partial_right.php
+++ b/functions/partial_right.php
@@ -33,3 +33,5 @@ function partial_right(callable $fn, ...$args): callable {
         return $fn(...array_merge($remainingArgs, $args));
     };
 }
+
+const partial_right = '\Garp\Functional\partial_right';

--- a/functions/pick.php
+++ b/functions/pick.php
@@ -30,3 +30,5 @@ function pick(array $allowed, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const pick = '\Garp\Functional\pick';

--- a/functions/pipe.php
+++ b/functions/pipe.php
@@ -34,3 +34,5 @@ function pipe(...$functions): callable {
 }
 
 
+
+const pipe = '\Garp\Functional\pipe';

--- a/functions/prop.php
+++ b/functions/prop.php
@@ -26,3 +26,5 @@ function prop($key, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const prop = '\Garp\Functional\prop';

--- a/functions/prop_equals.php
+++ b/functions/prop_equals.php
@@ -24,3 +24,5 @@ function prop_equals($prop, $value = null, $obj = null) {
         3
     )(...func_get_args());
 }
+
+const prop_equals = '\Garp\Functional\prop_equals';

--- a/functions/prop_in.php
+++ b/functions/prop_in.php
@@ -32,3 +32,5 @@ function prop_in(array $keys, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const prop_in = '\Garp\Functional\prop_in';

--- a/functions/prop_of.php
+++ b/functions/prop_of.php
@@ -25,3 +25,5 @@ function prop_of($collection, $prop = null) {
         2
     )(...func_get_args());
 }
+
+const prop_of = '\Garp\Functional\prop_of';

--- a/functions/prop_set.php
+++ b/functions/prop_set.php
@@ -28,3 +28,5 @@ function prop_set($key, $value = null, $object = null) {
         3
     )(...func_get_args());
 }
+
+const prop_set = '\Garp\Functional\prop_set';

--- a/functions/publish.php
+++ b/functions/publish.php
@@ -23,3 +23,5 @@ function publish(string $method, $context) {
     };
     return $caller->bindTo($context, $context);
 }
+
+const publish = '\Garp\Functional\publish';

--- a/functions/reduce.php
+++ b/functions/reduce.php
@@ -32,3 +32,5 @@ function reduce(callable $fn, $default, iterable $collection = null) {
         3
     )(...func_get_args());
 }
+
+const reduce = '\Garp\Functional\reduce';

--- a/functions/reduce_assoc.php
+++ b/functions/reduce_assoc.php
@@ -31,3 +31,5 @@ function reduce_assoc(callable $fn, $default, iterable $collection = null) {
         3
     )(...func_get_args());
 }
+
+const reduce_assoc = '\Garp\Functional\reduce_assoc';

--- a/functions/reduced.php
+++ b/functions/reduced.php
@@ -20,3 +20,5 @@ function reduced($value): Internal\ReducedValue {
         ? $value
         : new Internal\ReducedValue($value);
 }
+
+const reduced = '\Garp\Functional\reduced';

--- a/functions/reindex.php
+++ b/functions/reindex.php
@@ -18,3 +18,5 @@ namespace Garp\Functional;
 function reindex(array $collection): array {
     return array_values($collection);
 }
+
+const reindex = '\Garp\Functional\reindex';

--- a/functions/reject.php
+++ b/functions/reject.php
@@ -24,3 +24,5 @@ function reject(callable $predicate, iterable $collection = null) {
         2
     )(...func_get_args());
 }
+
+const reject = '\Garp\Functional\reject';

--- a/functions/rename_keys.php
+++ b/functions/rename_keys.php
@@ -42,3 +42,5 @@ function rename_keys($transformMap, array $collection = null) {
         2
     )(...func_get_args());
 }
+
+const rename_keys = '\Garp\Functional\rename_keys';

--- a/functions/repeat.php
+++ b/functions/repeat.php
@@ -37,3 +37,5 @@ function repeat(int $times, callable $fn): callable {
         return $accumulate($args);
     };
 }
+
+const repeat = '\Garp\Functional\repeat';

--- a/functions/replace.php
+++ b/functions/replace.php
@@ -29,3 +29,5 @@ function replace(string $regex, $replacement, $subject = null) {
         3
     )(...func_get_args());
 }
+
+const replace = '\Garp\Functional\replace';

--- a/functions/some.php
+++ b/functions/some.php
@@ -31,3 +31,5 @@ function some(callable $predicate, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const some = '\Garp\Functional\some';

--- a/functions/sort.php
+++ b/functions/sort.php
@@ -20,3 +20,5 @@ function sort(array $collection): array {
     \sort($copy);
     return $copy;
 }
+
+const sort = '\Garp\Functional\sort';

--- a/functions/sort_by.php
+++ b/functions/sort_by.php
@@ -33,3 +33,5 @@ function sort_by(callable $fn, array $collection = null) {
         2
     )(...func_get_args());
 }
+
+const sort_by = '\Garp\Functional\sort_by';

--- a/functions/sort_by_map.php
+++ b/functions/sort_by_map.php
@@ -34,3 +34,5 @@ function sort_by_map(array $map, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const sort_by_map = '\Garp\Functional\sort_by_map';

--- a/functions/split.php
+++ b/functions/split.php
@@ -23,3 +23,5 @@ function split(string $separator, string $subject = null) {
         2
     )(...func_get_args());
 }
+
+const split = '\Garp\Functional\split';

--- a/functions/subtract.php
+++ b/functions/subtract.php
@@ -42,3 +42,5 @@ function subtract($left, $right = null) {
         2
     )(...func_get_args());
 }
+
+const subtract = '\Garp\Functional\subtract';

--- a/functions/tail.php
+++ b/functions/tail.php
@@ -26,3 +26,5 @@ function tail($collection) {
         'tail expects argument 1 to be a collection'
     );
 }
+
+const tail = '\Garp\Functional\tail';

--- a/functions/take.php
+++ b/functions/take.php
@@ -39,3 +39,5 @@ function take(int $n, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const take = '\Garp\Functional\take';

--- a/functions/take_while.php
+++ b/functions/take_while.php
@@ -36,3 +36,5 @@ function take_while(callable $predicate, $collection = null) {
         2
     )(...func_get_args());
 }
+
+const take_while = '\Garp\Functional\take_while';

--- a/functions/tap.php
+++ b/functions/tap.php
@@ -21,3 +21,5 @@ function tap(callable $fn): callable {
         return $x;
     };
 }
+
+const tap = '\Garp\Functional\tap';

--- a/functions/truthy.php
+++ b/functions/truthy.php
@@ -22,3 +22,5 @@ function truthy($value) {
     }
     return !!$value;
 }
+
+const truthy = '\Garp\Functional\truthy';

--- a/functions/unary.php
+++ b/functions/unary.php
@@ -19,3 +19,5 @@ function unary(callable $fn): callable {
         return call_user_func($fn, $arg);
     };
 }
+
+const unary = '\Garp\Functional\unary';

--- a/functions/unique.php
+++ b/functions/unique.php
@@ -37,3 +37,5 @@ function unique($collection) {
         $collection
     );
 }
+
+const unique = '\Garp\Functional\unique';

--- a/functions/usort.php
+++ b/functions/usort.php
@@ -26,3 +26,5 @@ function usort(callable $fn, array $collection = null) {
         2
     )(...func_get_args());
 }
+
+const usort = '\Garp\Functional\usort';

--- a/functions/when.php
+++ b/functions/when.php
@@ -43,3 +43,5 @@ function when($condition, $ifTrue, $ifFalse, $subject = null) {
     }
     return is_callable_function($ifFalse) ? call_user_func($ifFalse, $subject) : $ifFalse;
 }
+
+const when = '\Garp\Functional\when';

--- a/functions/y.php
+++ b/functions/y.php
@@ -30,3 +30,5 @@ function Y($F): callable {
     );
 }
 
+
+const y = '\Garp\Functional\y';

--- a/functions/zip.php
+++ b/functions/zip.php
@@ -30,3 +30,5 @@ function zip(...$arrays) {
         $arrays
     );
 }
+
+const zip = '\Garp\Functional\zip';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,7 @@
     <exclude name="Generic.Commenting.DocComment.MissingShort"/>
     <exclude name="Generic.Commenting.DocComment.NonParamGroup"/>
     <exclude name="Generic.Commenting.DocComment.TagValueIndent"/>
+    <exclude name="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase"/>
     <exclude name="PEAR.Classes.ClassDeclaration.OpenBraceNewLine"/>
     <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag"/>
     <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag"/>

--- a/tests/AddTest.php
+++ b/tests/AddTest.php
@@ -21,4 +21,7 @@ class AddTest extends TestCase {
         $this->assertEquals(10, $add5(5));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\add));
+    }
 }

--- a/tests/AlwaysTest.php
+++ b/tests/AlwaysTest.php
@@ -21,4 +21,7 @@ class AlwaysTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\always));
+    }
 }

--- a/tests/AutocurryTest.php
+++ b/tests/AutocurryTest.php
@@ -29,4 +29,7 @@ class AutocurryTest extends TestCase {
 
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\autocurry));
+    }
 }

--- a/tests/BothTest.php
+++ b/tests/BothTest.php
@@ -65,4 +65,7 @@ class BothTest extends TestCase {
         $this->assertTrue($both);
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\both));
+    }
 }

--- a/tests/CallTest.php
+++ b/tests/CallTest.php
@@ -46,4 +46,7 @@ class CallTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\call));
+    }
 }

--- a/tests/ComposeTest.php
+++ b/tests/ComposeTest.php
@@ -45,4 +45,7 @@ class ComposeTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\compose));
+    }
 }

--- a/tests/ConcatRightTest.php
+++ b/tests/ConcatRightTest.php
@@ -119,4 +119,7 @@ class ConcatRightTest extends TestCase {
         f\concat_right('This', 'will', 'go', new stdClass(), 'wrong');
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\concat_right));
+    }
 }

--- a/tests/ConcatTest.php
+++ b/tests/ConcatTest.php
@@ -142,4 +142,7 @@ class ConcatTest extends TestCase {
         f\concat('This', 'will', 'go', new stdClass(), 'wrong');
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\concat));
+    }
 }

--- a/tests/ConcatWithTest.php
+++ b/tests/ConcatWithTest.php
@@ -58,4 +58,7 @@ class ConcatWithTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\concat_with));
+    }
 }

--- a/tests/ContainsTest.php
+++ b/tests/ContainsTest.php
@@ -76,4 +76,7 @@ class ContainsTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\contains));
+    }
 }

--- a/tests/CountTest.php
+++ b/tests/CountTest.php
@@ -71,4 +71,7 @@ class CountTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\count));
+    }
 }

--- a/tests/DivideTest.php
+++ b/tests/DivideTest.php
@@ -21,4 +21,7 @@ class DivideTest extends TestCase {
         $this->assertEquals(1, $divide5(5));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\divide));
+    }
 }

--- a/tests/DropTest.php
+++ b/tests/DropTest.php
@@ -65,4 +65,7 @@ class DropTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\drop));
+    }
 }

--- a/tests/DropWhileTest.php
+++ b/tests/DropWhileTest.php
@@ -86,4 +86,7 @@ class DropWhileTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\drop_while));
+    }
 }

--- a/tests/EitherTest.php
+++ b/tests/EitherTest.php
@@ -77,4 +77,7 @@ class EitherTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\either));
+    }
 }

--- a/tests/EntriesTest.php
+++ b/tests/EntriesTest.php
@@ -50,4 +50,7 @@ class EntriesTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\entries));
+    }
 }

--- a/tests/EqualsTest.php
+++ b/tests/EqualsTest.php
@@ -42,4 +42,7 @@ class EqualsTest extends TestCase {
         $this->assertTrue(f\equals($setoidB, $setoidB));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\equals));
+    }
 }

--- a/tests/EveryTest.php
+++ b/tests/EveryTest.php
@@ -25,4 +25,7 @@ class EveryTest extends TestCase {
         $this->assertTrue(is_callable($naughtButStrings));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\every));
+    }
 }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -88,4 +88,7 @@ class FilterTest extends TestCase {
         return strlen($str) <= 5;
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\filter));
+    }
 }

--- a/tests/FindIndexTest.php
+++ b/tests/FindIndexTest.php
@@ -65,4 +65,7 @@ class FindIndexTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\find_index));
+    }
 }

--- a/tests/FindTest.php
+++ b/tests/FindTest.php
@@ -58,4 +58,7 @@ class FindTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\find));
+    }
 }

--- a/tests/FlattenTest.php
+++ b/tests/FlattenTest.php
@@ -60,4 +60,7 @@ class FlattenTest extends TestCase {
             f\flatten($test)
         );
     }
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\flatten));
+    }
 }

--- a/tests/GroupByTest.php
+++ b/tests/GroupByTest.php
@@ -89,4 +89,7 @@ class GroupByTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\group_by));
+    }
 }

--- a/tests/GtTest.php
+++ b/tests/GtTest.php
@@ -39,4 +39,7 @@ class GtTest extends TestCase {
         $this->assertFalse(f\gt($small, $tiny));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\gt));
+    }
 }

--- a/tests/GteTest.php
+++ b/tests/GteTest.php
@@ -41,4 +41,7 @@ class GteTest extends TestCase {
         $this->assertFalse(f\gte($small, $tiny));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\gte));
+    }
 }

--- a/tests/HeadTest.php
+++ b/tests/HeadTest.php
@@ -49,4 +49,7 @@ class HeadTest extends TestCase {
         $this->assertNull(f\head(12345));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\head));
+    }
 }

--- a/tests/IdTest.php
+++ b/tests/IdTest.php
@@ -30,4 +30,7 @@ class IdTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\id));
+    }
 }

--- a/tests/IndexByTest.php
+++ b/tests/IndexByTest.php
@@ -73,4 +73,7 @@ class IndexByTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\index_by));
+    }
 }

--- a/tests/InstanceTest.php
+++ b/tests/InstanceTest.php
@@ -21,4 +21,7 @@ class InstanceTest extends TestCase {
         $this->assertInstanceOf('stdClass', f\instance('stdClass'));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\instance));
+    }
 }

--- a/tests/IsAssocTest.php
+++ b/tests/IsAssocTest.php
@@ -48,4 +48,7 @@ class IsAssocTest extends TestCase {
         ];
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\is_assoc));
+    }
 }

--- a/tests/IsCallableFunctionTest.php
+++ b/tests/IsCallableFunctionTest.php
@@ -49,4 +49,7 @@ class IsCallableFunctionTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\is_callable_function));
+    }
 }

--- a/tests/JoinTest.php
+++ b/tests/JoinTest.php
@@ -39,4 +39,7 @@ class JoinTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\join));
+    }
 }

--- a/tests/KeysTest.php
+++ b/tests/KeysTest.php
@@ -55,4 +55,7 @@ class KeysTest extends TestCase {
         f\keys(123);
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\keys));
+    }
 }

--- a/tests/KeysWhereTest.php
+++ b/tests/KeysWhereTest.php
@@ -29,4 +29,7 @@ class KeysWhereTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\keys_where));
+    }
 }

--- a/tests/LastTest.php
+++ b/tests/LastTest.php
@@ -48,4 +48,7 @@ class LastTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\last));
+    }
 }

--- a/tests/LtTest.php
+++ b/tests/LtTest.php
@@ -39,4 +39,7 @@ class LtTest extends TestCase {
         $this->assertTrue(f\lt($small, $tiny));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\lt));
+    }
 }

--- a/tests/LteTest.php
+++ b/tests/LteTest.php
@@ -42,4 +42,7 @@ class LteTest extends TestCase {
         $this->assertTrue(f\lte($small, $tiny));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\lte));
+    }
 }

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -59,4 +59,7 @@ class MapTest extends TestCase {
         return substr($str, 0, 3);
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\map));
+    }
 }

--- a/tests/MatchTest.php
+++ b/tests/MatchTest.php
@@ -72,4 +72,7 @@ class MatchTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\match));
+    }
 }

--- a/tests/MergeAfterTest.php
+++ b/tests/MergeAfterTest.php
@@ -257,4 +257,7 @@ class MergeAfterTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\merge_after));
+    }
 }

--- a/tests/ModuloTest.php
+++ b/tests/ModuloTest.php
@@ -21,4 +21,7 @@ class ModuloTest extends TestCase {
         $this->assertEquals(0, $modulo5(5));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\modulo));
+    }
 }

--- a/tests/MultiplyTest.php
+++ b/tests/MultiplyTest.php
@@ -21,4 +21,7 @@ class MultiplyTest extends TestCase {
         $this->assertEquals(25, $multiply5(5));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\multiply));
+    }
 }

--- a/tests/NoneTest.php
+++ b/tests/NoneTest.php
@@ -27,4 +27,7 @@ class NoneTest extends TestCase {
         $this->assertFalse($noStrings($data));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\none));
+    }
 }

--- a/tests/NotTest.php
+++ b/tests/NotTest.php
@@ -15,4 +15,7 @@ class NotTest extends TestCase {
         $this->assertFalse($noArray(array(1,2,3)));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\not));
+    }
 }

--- a/tests/OmitTest.php
+++ b/tests/OmitTest.php
@@ -66,4 +66,7 @@ class OmitTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\omit));
+    }
 }

--- a/tests/OnceTest.php
+++ b/tests/OnceTest.php
@@ -52,4 +52,7 @@ class OnceTest extends TestCase {
     public function setUp() {
         $this->_counter = 0;
     }
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\once));
+    }
 }

--- a/tests/PartialRightTest.php
+++ b/tests/PartialRightTest.php
@@ -34,4 +34,7 @@ class PartialRightTest extends TestCase {
         $this->assertEquals($expected, $helloCopy('John', 'Linda', 'Hi there!'));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\partial_right));
+    }
 }

--- a/tests/PartialTest.php
+++ b/tests/PartialTest.php
@@ -46,4 +46,7 @@ class PartialTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\partial));
+    }
 }

--- a/tests/PickTest.php
+++ b/tests/PickTest.php
@@ -75,4 +75,7 @@ class PickTest extends TestCase {
             $picked
         );
     }
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\pick));
+    }
 }

--- a/tests/PipeTest.php
+++ b/tests/PipeTest.php
@@ -45,4 +45,7 @@ class PipeTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\pipe));
+    }
 }

--- a/tests/PropInTest.php
+++ b/tests/PropInTest.php
@@ -66,4 +66,7 @@ class PropInTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\prop_in));
+    }
 }

--- a/tests/PropOfTest.php
+++ b/tests/PropOfTest.php
@@ -61,4 +61,7 @@ class PropOfTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\prop_of));
+    }
 }

--- a/tests/PropSetTest.php
+++ b/tests/PropSetTest.php
@@ -96,4 +96,7 @@ class PropSetTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\prop_set));
+    }
 }

--- a/tests/PropTest.php
+++ b/tests/PropTest.php
@@ -112,4 +112,7 @@ class PropTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\prop));
+    }
 }

--- a/tests/PublishTest.php
+++ b/tests/PublishTest.php
@@ -20,4 +20,7 @@ class PublishTest extends TestCase {
         return $n * $n;
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\publish));
+    }
 }

--- a/tests/ReduceAssocTest.php
+++ b/tests/ReduceAssocTest.php
@@ -76,4 +76,7 @@ class ReduceAssocTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\reduce_assoc));
+    }
 }

--- a/tests/ReduceTest.php
+++ b/tests/ReduceTest.php
@@ -92,4 +92,7 @@ class ReduceTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\reduce));
+    }
 }

--- a/tests/ReindexTest.php
+++ b/tests/ReindexTest.php
@@ -23,4 +23,7 @@ class ReindexTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\reindex));
+    }
 }

--- a/tests/RejectTest.php
+++ b/tests/RejectTest.php
@@ -86,4 +86,7 @@ class RejectTest extends TestCase {
         return strlen($str) <= 5;
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\reject));
+    }
 }

--- a/tests/RenameKeysTest.php
+++ b/tests/RenameKeysTest.php
@@ -114,4 +114,7 @@ class RenameKeysTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\rename_keys));
+    }
 }

--- a/tests/RepeatTest.php
+++ b/tests/RepeatTest.php
@@ -29,4 +29,7 @@ class RepeatTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\repeat));
+    }
 }

--- a/tests/ReplaceTest.php
+++ b/tests/ReplaceTest.php
@@ -57,4 +57,7 @@ class ReplaceTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\replace));
+    }
 }

--- a/tests/SomeTest.php
+++ b/tests/SomeTest.php
@@ -27,4 +27,7 @@ class SomeTest extends TestCase {
         $this->assertTrue($hasNumbers($stuff));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\some));
+    }
 }

--- a/tests/SortByMapTest.php
+++ b/tests/SortByMapTest.php
@@ -76,4 +76,7 @@ class SortByMapTest extends TestCase {
         $this->assertTrue(is_callable(f\sort_by_map(['foo', 'bar'])));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\sort_by_map));
+    }
 }

--- a/tests/SortByTest.php
+++ b/tests/SortByTest.php
@@ -61,4 +61,7 @@ class SortByTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\sort_by));
+    }
 }

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -25,4 +25,7 @@ class SplitTest extends TestCase {
         $this->assertTrue(is_callable($splitOnSpace));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\split));
+    }
 }

--- a/tests/SubtractTest.php
+++ b/tests/SubtractTest.php
@@ -22,4 +22,7 @@ class SubtractTest extends TestCase {
         $this->assertEquals(5, $subtract5(10));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\subtract));
+    }
 }

--- a/tests/TailTest.php
+++ b/tests/TailTest.php
@@ -55,4 +55,7 @@ class TailTest extends TestCase {
         f\tail(12345);
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\tail));
+    }
 }

--- a/tests/TakeTest.php
+++ b/tests/TakeTest.php
@@ -67,4 +67,7 @@ class TakeTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\take));
+    }
 }

--- a/tests/TakeWhileTest.php
+++ b/tests/TakeWhileTest.php
@@ -66,4 +66,7 @@ class TakeWhileTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\take_while));
+    }
 }

--- a/tests/TapTest.php
+++ b/tests/TapTest.php
@@ -21,4 +21,7 @@ class TapTest extends TestCase {
         $this->assertCount(2, $stuff);
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\tap));
+    }
 }

--- a/tests/TruthyTest.php
+++ b/tests/TruthyTest.php
@@ -31,4 +31,7 @@ class TruthyTest extends TestCase {
         $this->assertTrue(f\truthy($obj));
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\truthy));
+    }
 }

--- a/tests/UniqueTest.php
+++ b/tests/UniqueTest.php
@@ -74,4 +74,7 @@ class UniqueTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\unique));
+    }
 }

--- a/tests/UsortTest.php
+++ b/tests/UsortTest.php
@@ -39,4 +39,7 @@ class UsortTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\usort));
+    }
 }

--- a/tests/WhenTest.php
+++ b/tests/WhenTest.php
@@ -60,4 +60,7 @@ class WhenTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\when));
+    }
 }

--- a/tests/ZipTest.php
+++ b/tests/ZipTest.php
@@ -82,4 +82,7 @@ class ZipTest extends TestCase {
         );
     }
 
+    public function test_named_constant() {
+        $this->assertTrue(is_callable(f\zip));
+    }
 }


### PR DESCRIPTION
Every function now also exports a const with the same name, allowing
for easier composition because you can do this:

```
f\compose(
    f\flatten
    f\entries
);
```