### PR TITLE
Use strict checking in in_array in pick

### DIFF
--- a/functions/pick.php
+++ b/functions/pick.php
@@ -19,7 +19,7 @@ function pick(array $allowed, $collection = null) {
     return autocurry(
         function ($allowed, $collection): array {
             $keys = filter(
-                partial_right('in_array', $allowed),
+                partial_right('in_array', $allowed, true),
                 keys($collection)
             );
             return array_combine(

--- a/tests/PickTest.php
+++ b/tests/PickTest.php
@@ -35,6 +35,24 @@ class PickTest extends TestCase {
         );
     }
 
+    public function test_should_work_with_combined_arrays() {
+        $data = array(
+            0 => 'something',
+            'first' => 'another',
+            'second' => 'it continues',
+            'third' => 'test passed'
+        );
+        $fixture = array(
+            'first' => 'another',
+            'third' => 'test passed'
+        );
+
+        $this->assertEquals(
+            $fixture,
+            f\pick(array('first', 'third'), $data)
+        );
+    }
+
     public function test_should_be_curried() {
         $getFullName = f\pick(array('first_name', 'last_name'));
         $data = array(


### PR DESCRIPTION
Ik kan niet goed overzien wat de gevolgen van deze verandering zijn, maar de `in_array` functie is redelijk onvoorspelbaar zonder strict comparison. Bijvoorbeeld in de test die ik heb toegevoegd, zonder strict comparison komt de waarde van `0` gewoon mee in het resultaat want `in_array(0, ['first', 'third']) == true`.