### PR TITLE
Remove always false statement

### DIFF
--- a/functions/take.php
+++ b/functions/take.php
@@ -30,7 +30,6 @@ function take(int $n, $collection = null) {
                 $collection = str_split($collection);
                 $reduce = compose(join(''), $reduce);
             }
-            $collection = is_string($collection) ? str_split($collection) : $collection;
             if (!is_iterable($collection)) {
                 throw new \InvalidArgumentException('take expects argument 2 to be a collection');
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -501,11 +501,6 @@ parameters:
 			path: functions/split.php
 
 		-
-			message: "#^Call to function is_string\\(\\) with mixed will always evaluate to false\\.$#"
-			count: 1
-			path: functions/take.php
-
-		-
 			message: "#^Function Garp\\\\Functional\\\\take\\(\\) has parameter \\$collection with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: functions/take.php


### PR DESCRIPTION
Four lines above a `is_string` check is already done. When true it splits the string into an array which makes the second `is_string` check always false.